### PR TITLE
Fix: Correctly package release assets for BRAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,10 @@ jobs:
         run: |
           npm run test
 
+      - name: Package plugin
+        run: |
+          zip plugin.zip main.js manifest.json styles.css
+
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,4 +46,4 @@ jobs:
           latest_tag=$(git describe --tags --abbrev=0)
           gh release create "$latest_tag" \
             --title="$latest_tag" \
-            main.js manifest.json
+            plugin.zip


### PR DESCRIPTION
The previous release workflow attached `main.js` and `manifest.json` as individual assets to the GitHub release. This is not a format that the Obsidian plugin installer BRAT recognizes, leading to an error about a missing `manifest.json` file.

This change modifies the `.github/workflows/release.yml` to:
1. Create a `plugin.zip` file containing `main.js`, `manifest.json`, and `styles.css`.
2. Attach this `plugin.zip` file as the sole release asset.

This is the standard packaging format for Obsidian plugins and will allow BRAT to correctly install the plugin.