### PR TITLE
Fix: Ensure robust plugin loading and correct release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,10 @@ jobs:
         run: |
           npm run test
 
+      - name: Package plugin
+        run: |
+          zip plugin.zip main.js manifest.json styles.css
+
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,4 +46,4 @@ jobs:
           latest_tag=$(git describe --tags --abbrev=0)
           gh release create "$latest_tag" \
             --title="$latest_tag" \
-            main.js manifest.json
+            plugin.zip

--- a/src/datacore-utils.ts
+++ b/src/datacore-utils.ts
@@ -1,8 +1,8 @@
 import { UnsafeApp } from "./types";
-import { DatacoreApi } from "@blacksmithgu/datacore";
+import { DatacoreApi, getAPI } from "@blacksmithgu/datacore";
 
 export function getDatacoreAPI(app?: UnsafeApp | undefined): DatacoreApi {
-  const api = app?.plugins.plugins["datacore"]?.api as DatacoreApi;
+  const api = getAPI(app);
 
   if (!api) {
     throw new Error("Datacore API not found");


### PR DESCRIPTION
This commit addresses two issues that prevented the plugin from being installed via BRAT.

1.  **Fix Plugin Loading Error:** The plugin was failing to load due to a runtime error when trying to access the Datacore API. The manual API access method (`app.plugins.plugins["datacore"]?.api`) was brittle and would fail if the Datacore plugin had not yet loaded. This has been replaced with the official `getAPI()` function from the `@blacksmithgu/datacore` package, which is the robust and correct way to get the API. This resolves the root cause of the "missing manifest.json" error reported by Obsidian.

2.  **Improve Release Packaging:** The GitHub Actions release workflow has been updated to create a single `plugin.zip` file containing all necessary assets (`main.js`, `manifest.json`, `styles.css`). This is the standard format expected by BRAT and ensures a reliable installation process.